### PR TITLE
OS X Update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 # Ignore bundler config
 /.bundle
 
+# Ignore generated data directory
+/data
+
 # Ignore the default SQLite database.
 /db/*.sqlite3
 

--- a/Gemfile
+++ b/Gemfile
@@ -8,8 +8,8 @@ gem 'nokogiri'
 gem 'haml'
 gem 'textacular', require: 'textacular/rails'
 gem 'jquery-rails', '2.1.4'
-gem 'therubyracer', '~> 0.11.1'
-gem 'libv8', '~> 3.11.8.3', :platform => :ruby
+gem 'therubyracer', '~> 0.12.1'
+gem 'libv8', '~> 3.16.14.7', :platform => :ruby
 gem 'exception_notification'
 gem 'rake'
 gem 'xpath'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,7 +95,7 @@ GEM
       less (~> 2.3.1)
     less-rails-bootstrap (2.3.3)
       less-rails (~> 2.3.1)
-    libv8 (3.11.8.17)
+    libv8 (3.16.14.7)
     lograge (0.3.0)
       actionpack (>= 3)
       activesupport (>= 3)
@@ -202,8 +202,8 @@ GEM
       tins (~> 1.0)
     textacular (3.2.0)
       activerecord (>= 3.0, < 4.2)
-    therubyracer (0.11.4)
-      libv8 (~> 3.11.8.12)
+    therubyracer (0.12.1)
+      libv8 (~> 3.16.14.0)
       ref
     thor (0.19.1)
     tilt (1.4.1)
@@ -237,7 +237,7 @@ DEPENDENCIES
   jquery-rails (= 2.1.4)
   launchy
   less-rails-bootstrap (= 2.3.3)
-  libv8 (~> 3.11.8.3)
+  libv8 (~> 3.16.14.7)
   lograge
   nokogiri
   pg
@@ -253,6 +253,6 @@ DEPENDENCIES
   stamp
   syslog-logger
   textacular
-  therubyracer (~> 0.11.1)
+  therubyracer (~> 0.12.1)
   uglifier (>= 1.0.3)
   xpath

--- a/INSTALL-OSX
+++ b/INSTALL-OSX
@@ -52,7 +52,7 @@ rake dgidb:load_local
 #Occassionally the database may get into a confused state and this rake command no longer works properly
 #In that case you can try this:
 psql -h localhost -d dgidb -f db/structure.sql
-psql -h localhost -d dgidb -f db/data.sql
+psql -h localhost -d dgidb -f data/data.sql
 
 #launch your development server
 rails s


### PR DESCRIPTION
A couple of updates to the dgi-db code for native operability with OS X 10.10.

therubyracer and libv8 needed to be updated for compatibility with gcc 4.8 (see https://github.com/cowboyd/libv8/pull/95)--these updates are implemented in this pull request. These updates do not impact the function of the site or cause any tests to fail in a linux test environment.

In addition, the dgidb:load_local troubleshooting step in the OS X install instructions refers to the incorrect location for data.sql. This is addressed below.
