### PR TITLE
OS X update

### DIFF
--- a/INSTALL-OSX
+++ b/INSTALL-OSX
@@ -1,12 +1,15 @@
 #These instructions are for OSX 10.7 (Lion) and above
 
 #Install RVM with Ruby and Rails: https://rvm.io/rvm/install
-#You want to install Ruby 1.9.x or newer (we have tested 1.9.x and 2.0.x).
+#You want to install Ruby 1.9.x or 2.0.x (we have tested 1.9.x and 2.0.x). Ruby 2.2 causes failures.
     \curl -L https://get.rvm.io | bash -s stable --rails
 
 #To check your version of Ruby:
 ruby -v
-rvm --default use
+
+#To install and use Ruby 2.0.0:
+rvm install 2.0.0
+rvm use 2.0.0
 
 #If you have trouble installing Ruby on Mac OSX 10.8 (Mountain Lion), the issue may be your Xcode install
 #In that case, this post might be informative

--- a/lib/tasks/db_bootstrapping.rake
+++ b/lib/tasks/db_bootstrapping.rake
@@ -20,7 +20,7 @@ namespace :dgidb do
     #special case for macs running Postgres.app
     if RbConfig::CONFIG['host_os'] =~ /darwin/ && File.exist?( '/Applications/Postgres.app' )
       puts 'Found Postgres.app'
-      ENV['PATH'] = "/Applications/Postgres.app/Contents/MacOS/bin:#{ENV['PATH']}"
+      ENV['PATH'] = "/Applications/Postgres.app/Contents/Versions/9.4/bin:#{ENV['PATH']}"
     end
 
     # MacPorts Handling


### PR DESCRIPTION
Update OS X install directions and db_bootstrapping.rake to overcome some difficulties observed in setting up a new dev environment on OS X 10.10