### PR TITLE
Add Guide To Pharmacology D-G Interaction Source

### DIFF
--- a/app/models/data_model/drug_claim.rb
+++ b/app/models/data_model/drug_claim.rb
@@ -30,10 +30,14 @@ module DataModel
         base_url + 'DRUG.asp?ID=' + name
       when 'TALC'
         'http://www.ncbi.nlm.nih.gov/pubmed/22005529/' #TODO: This is a hack.  Fix it with another db column
+                                                       #Alternative: set this as base_url in source.
       when 'TEND'
         'http://www.ncbi.nlm.nih.gov/pubmed/21804595/' #TODO: as above
+        																							 #Alternative: as above
       when 'MyCancerGenome', 'CancerCommons', 'ClearityFoundationBiomarkers', 'ClearityFoundationClinicalTrial', 'MyCancerGenomeClinicalTrial'
         base_url
+      when 'GuideToPharmacologyInteractions'
+        'http://www.guidetopharmacology.org/GRAC/LigandDisplayForward?ligandId=' + name
       else
         base_url + name
       end

--- a/app/models/data_model/gene_claim.rb
+++ b/app/models/data_model/gene_claim.rb
@@ -45,6 +45,8 @@ module DataModel
         base_url + 'Detail.asp?ID=' + name
       when 'GO'
         base_url.gsub(/XXXXXXXX/, name)
+      when 'GuideToPharmacologyInteractions'
+        'http://www.guidetopharmacology.org/GRAC/ObjectDisplayForward?objectId=' + name
       when 'MyCancerGenome', 'CancerCommons', 'ClearityFoundationBiomarkers', 'ClearityFoundationClinicalTrial', 'MyCancerGenomeClinicalTrial'
         base_url
       else

--- a/app/sort_orders/interaction_result_sort_order.rb
+++ b/app/sort_orders/interaction_result_sort_order.rb
@@ -15,12 +15,14 @@ module InteractionResultSortOrder
       6
     when 'TEND'
       7
-    when 'PharmGKB'
+    when 'GuideToPharmacologyInteractions'
       8
-    when 'TTD'
+    when 'PharmGKB'
       9
-    when 'DrugBank'
+    when 'TTD'
       10
+    when 'DrugBank'
+      11
     else
       99
     end

--- a/app/views/drug_claims/show.html.haml
+++ b/app/views/drug_claims/show.html.haml
@@ -2,7 +2,7 @@
 =content_for :title, "DGIdb - #{@drug_claim.title} Drug Record"
 =content_for :header do
   %h2
-    %span{id: "drug_name"}=@drug_claim.title
+    %span{id: "drug_name"}=@drug_claim.title.html_safe
     %small
       ="drug data from #{@drug_claim.source.source_db_name}"
 
@@ -14,7 +14,7 @@
           %h3 Drug Record
           %p
             %b Reported Drug Name:
-            =ext_link_to(@drug_claim.drug_claim_name, @drug_claim.original_data_source_url)
+            =ext_link_to(@drug_claim.drug_claim_name.html_safe, @drug_claim.original_data_source_url)
           %p
             %b Source Database Name:
             =link_to @drug_claim.source.source_db_name, source_path(@drug_claim.source.source_db_name)

--- a/app/views/interaction_claims/_interaction_table_row.html.haml
+++ b/app/views/interaction_claims/_interaction_table_row.html.haml
@@ -4,13 +4,13 @@
   %td{title: interaction_table_row.gene_name + ' - ' + interaction_table_row.gene_long_name, class: "truncate"}
     = link_to gene_path(interaction_table_row.gene_name) do
       %strong
-        = interaction_table_row.gene_name
+        = interaction_table_row.gene_name.html_safe
       = " - "
       %em
         %small
-          =interaction_table_row.gene_long_name
+          =interaction_table_row.gene_long_name.html_safe
   %td{title: interaction_table_row.drug_claim_name}
-    =link_to truncate(interaction_table_row.drug_claim_name, length:50), drug_claim_path(interaction_table_row.interaction_claim.drug_claim)
+    =link_to truncate(interaction_table_row.drug_claim_name.html_safe, length:50), drug_claim_path(interaction_table_row.interaction_claim.drug_claim)
   %td
     =link_to interaction_table_row.types_string, interaction_claims_path(interaction_table_row.interaction_claim)
   %td

--- a/db/migrate/20130712225648_add_inter_gene_interaction_count_to_sources.rb
+++ b/db/migrate/20130712225648_add_inter_gene_interaction_count_to_sources.rb
@@ -1,6 +1,6 @@
 class AddInterGeneInteractionCountToSources < ActiveRecord::Migration
   def up
-    add_column :sources, :gene_gene_interaction_claims_count, :integer
+    add_column :sources, :gene_gene_interaction_claims_count, :integer, default: 0
   end
 
   def down

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -310,7 +310,7 @@ CREATE TABLE sources (
     gene_claims_in_groups_count integer DEFAULT 0,
     drug_claims_in_groups_count integer DEFAULT 0,
     source_trust_level_id character varying(255),
-    gene_gene_interaction_claims_count integer
+    gene_gene_interaction_claims_count integer DEFAULT 0
 );
 
 

--- a/lib/genome/importers/guide_to_pharmacology_interactions/guide_to_pharmacology_interactions_row.rb
+++ b/lib/genome/importers/guide_to_pharmacology_interactions/guide_to_pharmacology_interactions_row.rb
@@ -1,0 +1,58 @@
+require 'genome/importers/delimited_row'
+module Genome
+  module Importers
+    module GuideToPharmacologyInteractions
+      class GuideToPharmacologyInteractionsRow < Genome::Importers::DelimitedRow
+        target_parser = ->(x) { if x.blank? 
+                                  return x
+                                elsif (x.in? ['t','f']) 
+                                  return (x == 't' ? 'True' : 'False')
+                                else
+                                  return ""
+                                end
+                              }
+        types = ['Activator', 'Agonist', 'Allosteric', 'Antagonist', 'Antibody',
+                 'Channel', 'Gating', 'Inhibitor', 'Subunit-specific']
+        attribute :target
+        attribute :target_id
+        attribute :target_gene_symbol, Array, delimiter: '|'
+        attribute :target_uniprot, Array, delimiter: '|'
+        attribute :target_ligand, Array, delimiter: '|'
+        attribute :target_ligand_id
+        attribute :target_ligand_gene_symbol
+        attribute :target_ligand_uniprot
+        attribute :target_ligand_pubchem_sid
+        attribute :target_species
+        attribute :ligand
+        attribute :ligand_id
+        attribute :ligand_gene_symbol
+        attribute :ligand_species
+        attribute :ligand_pubchem_sid
+        attribute :type, String, parser: ->(x) {(x.in? types) ? x.downcase : 'unknown'}
+        attribute :action
+        attribute :action_comment
+        attribute :endogenous, String, parser: ->(x) {x == 't' ? 'True' : 'False'}
+        attribute :primary_target, String, parser: target_parser
+        attribute :concentration_range
+        attribute :affinity_units
+        attribute :affinity_high
+        attribute :affinity_median
+        attribute :affinity_low
+        attribute :original_affinity_units
+        attribute :original_affinity_low_nm
+        attribute :original_affinity_median_nm
+        attribute :original_affinity_high_nm
+        attribute :original_affinity_relation
+        attribute :assay_description
+        attribute :receptor_site
+        attribute :ligand_context
+        attribute :pubmed_id, Array, delimiter: '|'
+
+        def valid?(opts = {})
+          tests = [target_species == 'Human', target_ligand.blank?]
+          tests.all?
+        end
+      end
+    end
+  end
+end

--- a/lib/genome/importers/guide_to_pharmacology_interactions/guide_to_pharmacology_interactions_tsv_importer.rb
+++ b/lib/genome/importers/guide_to_pharmacology_interactions/guide_to_pharmacology_interactions_tsv_importer.rb
@@ -4,7 +4,7 @@ module Genome
 
       def self.source_info
         {
-          base_url: 'http://www.guidetopharmacology.org/DATA/interactions.csv',
+          base_url: 'http://www.guidetopharmacology.org/DATA/',
           site_url: 'http://www.guidetopharmacology.org/',
           citation: 'Pawson, Adam J., et al. "The IUPHAR/BPS Guide to PHARMACOLOGY: an expert-driven knowledgebase of drug targets and their ligands." Nucleic acids research 42.D1 (2014): D1098-D1106. PMID: 24234439.',
           source_db_version: '4-Mar-2015',
@@ -21,16 +21,15 @@ module Genome
         downcase = ->(x) {x.downcase}
         TSVImporter.import tsv_path, GuideToPharmacologyInteractionsRow, source_info do
           interaction known_action_type: :type, transform: downcase do
-            drug :ligand, nomenclature: 'GuideToPharmacology Primary Drug Name', primary_name: :ligand, transform: upcase do
-              attribute :ligand_id, name: 'GuideToPharmacology Ligand Identifier', unless: blank_filter
+            drug :ligand_id, nomenclature: 'GuideToPharmacology Ligand Identifier', primary_name: :ligand, transform: upcase do
               name :ligand_gene_symbol, nomenclature: 'Gene Symbol (for Endogenous Peptides)', unless: blank_filter
               attribute :ligand_species, name: 'Name of the Ligand Species (if a Peptide)', unless: blank_filter
               name :ligand_pubchem_sid, nomenclature: 'PubChem Substance ID', unless: blank_filter
             end
-            gene :target, nomenclature: 'GuideToPharmacology Name' do
+            gene :target_id, nomenclature: 'GuideToPharmacology ID' do
               names :target_uniprot, nomenclature: 'UniProtKB ID', unless: blank_filter
               names :target_gene_symbol, nomenclature: 'Gene Symbol', unless: blank_filter
-              name :target_id, nomenclature: 'GuideToPharmacology ID', unless: blank_filter
+              name :target, nomenclature: 'GuideToPharmacology Name', unless: blank_filter
               # target_ligand fields are ignored for now.
             end
 

--- a/lib/genome/normalizers/source_trust_level.rb
+++ b/lib/genome/normalizers/source_trust_level.rb
@@ -21,6 +21,7 @@ module Genome
             'ClearityFoundationBiomarker',
             'ClearityFoundationClinical',
             'Entrez',
+            'GuideToPharmacologyInteractions',
           ],
         'Non-curated' =>
           [

--- a/text/news.yml
+++ b/text/news.yml
@@ -116,5 +116,5 @@ news:
     - headline: IUPHAR/BPS Guide to Pharmacology added as new source of drug-gene interactions
       article : >
         Expert-curated drug-gene interactions from <a href="http://guidetopharmacology.org/">IUPHAR/BPD Guide to Pharmacology</a> has been added as a new source of drug-gene interactions.
-      date: Mar 18, 2014
+      date: Mar 18, 2015
 

--- a/text/news.yml
+++ b/text/news.yml
@@ -112,4 +112,9 @@ news:
       article : >
         Clinical trial data from <a href="http://www.mycancergenome.org/">My Cancer Genome</a> has been added to DGIdb as a new source of drug-gene interactions.
       date: Jun 9, 2014
+      
+    - headline: IUPHAR/BPS Guide to Pharmacology added as new source of drug-gene interactions
+      article : >
+        Expert-curated drug-gene interactions from <a href="http://guidetopharmacology.org/">IUPHAR/BPD Guide to Pharmacology</a> has been added as a new source of drug-gene interactions.
+      date: Mar 18, 2014
 


### PR DESCRIPTION
Add guide_to_pharmacology interactions from http://www.guidetopharmacology.org/about.jsp. Update schema to add default values for gene-gene interaction counts (minor fix).

Data file for import may be found here: https://www.dropbox.com/s/7t0z8iv8zbjgoss/gtp_interactions.4_mar_2015.expected_cols.tsv?dl=0

rake command:
rake dgidb:import:guide_to_pharmacology_interactions[path_to_gtp_interactions_tsv,true]