### PR TITLE
Update GuideToPharmacologyInteractions importer. Update drug grouper.

### DIFF
--- a/config/initializers/string.rb
+++ b/config/initializers/string.rb
@@ -1,5 +1,0 @@
-class String
-  def sanitize
-    self.gsub(/<.*?>/, '')
-  end
-end

--- a/config/initializers/string.rb
+++ b/config/initializers/string.rb
@@ -1,0 +1,5 @@
+class String
+  def sanitize
+    self.gsub(/<.*?>/, '')
+  end
+end

--- a/lib/genome/importers/clearity_foundation_clinical_trial/clearity_foundation_clinical_trial_tsv_importer.rb
+++ b/lib/genome/importers/clearity_foundation_clinical_trial/clearity_foundation_clinical_trial_tsv_importer.rb
@@ -16,7 +16,7 @@
         end
 
         def self.run(tsv_path)
-          blank_filter = ->(x) { x.blank? }
+          blank_filter = ->(x) { x.blank? || x.upcase == 'N/A' || x.upcase == 'NA' }
           upcase = ->(x) { x.upcase }
           TSVImporter.import tsv_path, ClearityFoundationClinicalTrialRow, source_info do
             interaction known_action_type: :interaction_type do

--- a/lib/genome/importers/guide_to_pharmacology_interactions/guide_to_pharmacology_interactions_tsv_importer.rb
+++ b/lib/genome/importers/guide_to_pharmacology_interactions/guide_to_pharmacology_interactions_tsv_importer.rb
@@ -1,7 +1,8 @@
+include ActionView::Helpers::SanitizeHelper
+
 module Genome
   module Importers
     module GuideToPharmacologyInteractions
-      include ActionView::Helpers::SanitizeHelper
 
       def self.source_info
         {

--- a/lib/genome/importers/guide_to_pharmacology_interactions/guide_to_pharmacology_interactions_tsv_importer.rb
+++ b/lib/genome/importers/guide_to_pharmacology_interactions/guide_to_pharmacology_interactions_tsv_importer.rb
@@ -19,12 +19,14 @@ module Genome
         blank_filter = ->(x) { x.blank? || x == "''" || x == '""' }
         upcase = ->(x) {x.upcase}
         downcase = ->(x) {x.downcase}
+        clean = ->(x) {x.sanitize.upcase}
         TSVImporter.import tsv_path, GuideToPharmacologyInteractionsRow, source_info do
           interaction known_action_type: :type, transform: downcase do
             drug :ligand_id, nomenclature: 'GuideToPharmacology Ligand Identifier', primary_name: :ligand, transform: upcase do
               name :ligand_gene_symbol, nomenclature: 'Gene Symbol (for Endogenous Peptides)', unless: blank_filter
+              name :ligand, nomenclature: 'GuideToPharmacology Ligand Name', transform: clean
               attribute :ligand_species, name: 'Name of the Ligand Species (if a Peptide)', unless: blank_filter
-              name :ligand_pubchem_sid, nomenclature: 'PubChem Substance ID', unless: blank_filter
+              name :ligand_pubchem_sid, nomenclature: 'PubChem Drug SID', unless: blank_filter
             end
             gene :target_id, nomenclature: 'GuideToPharmacology ID' do
               names :target_uniprot, nomenclature: 'UniProtKB ID', unless: blank_filter

--- a/lib/genome/importers/guide_to_pharmacology_interactions/guide_to_pharmacology_interactions_tsv_importer.rb
+++ b/lib/genome/importers/guide_to_pharmacology_interactions/guide_to_pharmacology_interactions_tsv_importer.rb
@@ -1,6 +1,7 @@
 module Genome
   module Importers
     module GuideToPharmacologyInteractions
+      include ActionView::Helpers::SanitizeHelper
 
       def self.source_info
         {
@@ -19,7 +20,7 @@ module Genome
         blank_filter = ->(x) { x.blank? || x == "''" || x == '""' }
         upcase = ->(x) {x.upcase}
         downcase = ->(x) {x.downcase}
-        clean = ->(x) {x.sanitize.upcase}
+        clean = ->(x) {strip_tags x.upcase}
         TSVImporter.import tsv_path, GuideToPharmacologyInteractionsRow, source_info do
           interaction known_action_type: :type, transform: downcase do
             drug :ligand_id, nomenclature: 'GuideToPharmacology Ligand Identifier', primary_name: :ligand, transform: upcase do

--- a/lib/tasks/importers.rake
+++ b/lib/tasks/importers.rake
@@ -29,6 +29,8 @@ namespace :dgidb do
           if args[:group]
             puts 'Running Gene Grouper - this takes awhile!'
             Genome::Groupers::GeneGrouper.run
+            puts 'Running Drug Grouper - this takes awhile!'
+            Genome::Groupers::DrugGrouper.run
           end
 
           puts 'Populating source counters.'


### PR DESCRIPTION
Add in nomenclature-sensitive drug grouping for numeric names. Update GTP Interactions to include a "sanitized", html-free version of `primary_name` as a `drug_alias`.