### PR TITLE
Initial DoCM Importer

### DIFF
--- a/lib/genome/importers/docm/docm_row.rb
+++ b/lib/genome/importers/docm/docm_row.rb
@@ -1,0 +1,15 @@
+require 'genome/importers/delimited_row'
+module Genome
+  module Importers
+    module Docm
+      class DocmRow < Genome::Importers::DelimitedRow
+        attribute :gene
+        attribute :entrez_id
+        attribute :drug
+        attribute :effect
+        attribute :pathway
+        attribute :status
+      end
+    end
+  end
+end

--- a/lib/genome/importers/docm/docm_row.rb
+++ b/lib/genome/importers/docm/docm_row.rb
@@ -5,7 +5,7 @@ module Genome
       class DocmRow < Genome::Importers::DelimitedRow
         attribute :gene
         attribute :entrez_id
-        attribute :drug
+        attribute :drug, String, parser: ->(x) { x.upcase }
         attribute :effect
         attribute :pathway
         attribute :status

--- a/lib/genome/importers/docm/docm_tsv_importer.rb
+++ b/lib/genome/importers/docm/docm_tsv_importer.rb
@@ -1,0 +1,25 @@
+module Genome
+  module Importers
+    module Docm
+
+      def self.source_info
+        {
+            base_url: 'http://docm.genome.wustl.edu/',
+            citation: 'Manuscript in preparation. Please cite http://docm.genome.wustl.edu/',
+            source_db_version: '25-Aug-2015',
+            source_type_id: DataModel::SourceType.INTERACTION,
+            source_trust_level_id: DataModel::SourceTrustLevel.EXPERT_CURATED,
+            source_db_name: 'DoCM',
+            full_name: 'Database of Curated Mutations'
+        }
+      end
+
+      def self.run(tsv_path)
+        TSVImporter.import tsv_path, DocmRow, source_info do
+          interaction
+        end
+      end
+
+    end
+  end
+end

--- a/lib/genome/importers/docm/docm_tsv_importer.rb
+++ b/lib/genome/importers/docm/docm_tsv_importer.rb
@@ -16,10 +16,17 @@ module Genome
 
       def self.run(tsv_path)
         TSVImporter.import tsv_path, DocmRow, source_info do
-          interaction
-        end
+          interaction known_action_type: :effect do
+            drug :drug, nomenclature: 'DoCM Drug Name', primary_name: :drug do
+            end
+            gene :gene, nomenclature: 'DoCM Entrez Gene Symbol' do
+              name :entrez_id, nomenclature: 'Entrez Gene Id'
+            end
+            attribute :status, name: 'Clinical Status'
+            attribute :pathway, name: 'Pathway'
+          end
+        end.save!
       end
-
     end
   end
 end

--- a/lib/genome/importers/docm/docm_tsv_importer.rb
+++ b/lib/genome/importers/docm/docm_tsv_importer.rb
@@ -16,7 +16,7 @@ module Genome
 
       def self.run(tsv_path)
         TSVImporter.import tsv_path, DocmRow, source_info do
-          interaction known_action_type: :effect do
+          interaction known_action_type: 'n/a' do
             drug :drug, nomenclature: 'DoCM Drug Name', primary_name: :drug do
             end
             gene :gene, nomenclature: 'DoCM Entrez Gene Symbol' do
@@ -24,6 +24,7 @@ module Genome
             end
             attribute :status, name: 'Clinical Status'
             attribute :pathway, name: 'Pathway'
+            attribte :effect, name: 'Variant Effect'
           end
         end.save!
       end

--- a/lib/genome/updaters/get_docm.rb
+++ b/lib/genome/updaters/get_docm.rb
@@ -1,0 +1,78 @@
+require 'net/http'
+
+module Genome
+  module Updaters
+    class GetDocm
+      def docm_url
+        'http://docm.genome.wustl.edu/api/v1/variants.json'
+      end
+
+      def docm_params
+        {'detailed_view' => true}
+      end
+
+      def docm_variants
+        @docm_variants ||= JSON.parse(get_docm_variants)
+      end
+
+      def get_docm_variants
+        uri = URI(docm_url)
+
+        uri.query = URI.encode_www_form(docm_params)
+
+        req = Net::HTTP::Get.new(uri)
+        resp = Net::HTTP.start(uri.host, uri.port) { |http| http.request(req)}
+        if resp.code != '200'
+          raise StandardError.new('Failed HTTP request')
+        end
+
+        resp.body
+      end
+
+      def process_drugs(drug_row)
+        drug_row.split(/,|\+|plus/)
+          .map(&:strip)
+          .reject { |drug_name| drug_name =~ /inhib/ }
+          .reject { |drug_name| drug_name =~ /HER3/ }
+          .reject { |drug_name| drug_name =~ /TKI/ }
+          .reject { |drug_name| drug_name =~ /anti/ }
+          .reject { |drug_name| drug_name =~ /BRAF/ }
+          .reject { |drug_name| drug_name =~ /radio/ }
+          .reject { |drug_name| drug_name =~ /BH3/ }
+          .map{|drug_name| drug_name.split(/\s+/).first}
+      end
+
+      def to_rows
+        docm_variants.flat_map do |variant|
+          if variant['drug_interactions'].present?
+            variant['drug_interactions'].flat_map do |interaction|
+              process_drugs(interaction['drug']).map do |drug|
+                [
+                    variant['gene'],
+                    variant['entrez_id'],
+                    drug,
+                    interaction['effect'],
+                    interaction['pathway'],
+                    interaction['status']
+                ]
+              end
+            end
+          end
+        end.compact.reject(&:blank?)
+      end
+
+      def headers
+        ['gene', 'entrez_id', 'drug', 'effect', 'pathway', 'status']
+      end
+
+      def to_tsv(filename)
+        File.open(filename, 'w') do |file|
+          file.puts(headers.join("\t"))
+          to_rows.each do |row|
+            file.puts(row.join("\t"))
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is DoCM importer that @bainscou and I worked on. It is working successfully and imports the following items:

````
30 gene_claims.
30 gene_claim_aliases.
35 drug_claims.
88 interaction_claims.
176 interaction_claim_attributes.
````

All Genes have an Entrez ID and are thus grouped correctly by the gene grouper. Before merging we did have two questions:

 * There is a column in the DoCM TSV called `effect` which contains values like 
```
decreased sensitivity
effect
no response
educed sensitivity
resistance
response
sensitivity
````

and it is unclear to me if that should be imported as the `interaction_type` or the `known_action_type` of the interaction. 

 * Where should DoCM lie in the sort order of sources?

With those two questions answered, we should be good to go!