### PR TITLE
Fix typo in DoCM importer

### DIFF
--- a/lib/genome/importers/docm/docm_tsv_importer.rb
+++ b/lib/genome/importers/docm/docm_tsv_importer.rb
@@ -24,7 +24,7 @@ module Genome
             end
             attribute :status, name: 'Clinical Status'
             attribute :pathway, name: 'Pathway'
-            attribte :effect, name: 'Variant Effect'
+            attribute :effect, name: 'Variant Effect'
           end
         end.save!
       end


### PR DESCRIPTION
Simple fix to DoCM importer--a typo slipped through that breaks the importer.