### PR TITLE
Add links to Gene and Drug group views to By Source results page view

### DIFF
--- a/app/presenters/interaction_result_row_classes.rb
+++ b/app/presenters/interaction_result_row_classes.rb
@@ -30,9 +30,9 @@ module InteractionResultRowClasses
   end
 
   class InteractionBySource
-    attr_reader :name, :sources, :pmids, :score
-    def initialize(name, source_db_names, identifiers)
-      @name = name
+    attr_reader :names, :sources, :pmids, :score
+    def initialize(names, source_db_names, identifiers)
+      @names = names
       identifier_sources = identifiers.map(&:source_db_name)
       @sources  = source_db_names.map { |s| identifier_sources.include?(s) }
       pmid_claims = identifiers.flat_map(&:pmids)

--- a/app/presenters/interaction_search_results_presenter.rb
+++ b/app/presenters/interaction_search_results_presenter.rb
@@ -111,15 +111,15 @@ class InteractionSearchResultsPresenter
     unless @interactions_map_by_source_db_names
       if @search_context == 'genes'
         interaction_groups = definite_interactions.group_by do |presenter|
-          [presenter.drug_name, presenter.gene_name].join(" and ")
+          { gene: presenter.gene_name, drug: presenter.drug_name }
         end
       else
         interaction_groups = definite_interactions.group_by do |presenter|
-          [presenter.gene_name, presenter.drug_name].join(" and ")
+          { drug: presenter.drug_name, gene: presenter.gene_name}
         end
       end
-      @interactions_map_by_source_db_names = interaction_groups.map do |name, ids|
-        InteractionBySource.new(name, source_db_names_for_table, ids)
+      @interactions_map_by_source_db_names = interaction_groups.map do |names, ids|
+        InteractionBySource.new(names, source_db_names_for_table, ids)
       end
     end
     @interactions_map_by_source_db_names

--- a/app/views/interaction_claims/_results_by_source_table_row.html.haml
+++ b/app/views/interaction_claims/_results_by_source_table_row.html.haml
@@ -1,6 +1,8 @@
 %tr
   %td
-    =results_by_source_table_row.name
+    - name_links = results_by_source_table_row.names.map do |(type, name)|
+      - link_to(name, "/#{type}s/#{name}")
+    = name_links.join(' and ').html_safe
   -results_by_source_table_row.sources.each do |in_source|
     %td
       -if in_source


### PR DESCRIPTION
>In the By Source view for interaction results it would be awesome if you could directly link to the Gene and Drug group views from the interactions in the first column. 

Done!
Fixes #71