### PR TITLE
Fixes the `can't convert nil into String` bug.

### DIFF
--- a/app/models/gene_category_search_result.rb
+++ b/app/models/gene_category_search_result.rb
@@ -21,7 +21,7 @@ class GeneCategorySearchResult
   end
 
   def gene_display_name
-    genes.first.long_name
+    genes.first.long_name || genes.first.name
   end
 
   def gene

--- a/app/presenters/interaction_search_result_presenter.rb
+++ b/app/presenters/interaction_search_result_presenter.rb
@@ -58,7 +58,7 @@ class InteractionSearchResultPresenter
   def gene_long_name
     gene = @interaction_claim.gene_claim.genes.first
     if gene
-      return gene.long_name
+      return gene.long_name || gene.name
     end
     nil
   end


### PR DESCRIPTION
This bothered me, so I took another look at it.

It appears that any new genes we add don't have the "long name" field filled out, which was causing the error.

I'll have to do some digging to find out how this was loaded before we started adding genes for 2.0. My guess is that it was some backend magic.

@acoffman, do you know?