### PR TITLE
escape drug names with conflicting characters

### DIFF
--- a/app/controllers/drugs_controller.rb
+++ b/app/controllers/drugs_controller.rb
@@ -1,7 +1,7 @@
 class DrugsController < ApplicationController
 
   def show
-    drug = DataModel::Drug.for_show.where('lower(drugs.name) = ?', params[:name].downcase)
+    drug = DataModel::Drug.for_show.where('lower(drugs.name) = ?', CGI::unescape(params[:name].downcase))
       .first || not_found("No drug matches name #{params[:name]}")
 
     @drug = DrugPresenter.new(drug)

--- a/app/models/interaction_search_result.rb
+++ b/app/models/interaction_search_result.rb
@@ -7,26 +7,22 @@ class InteractionSearchResult
     @search_terms = search_terms
     @type = type
     @identifiers = identifiers.uniq
-    exclude_chars = %w{/ , [ (}
     if type == 'genes'
       results = identifiers.flat_map { |g| g.gene_claims }
         .flat_map{ |gc| gc.interaction_claims }
         .uniq
       @interaction_claims = results.reject do |ic|
-        ic.drug_claim.drugs.first.nil? ||
-        exclude_chars.any? { |char| ic.drug_claim.drugs.first.name.include?(char) }
+        ic.drug_claim.drugs.first.nil?
       end
 
-      # TODO: This is a hack that removes any interactions with drugs that have special characters. Needs to be addressed.
     else
       results = identifiers.flat_map { |d| d.drug_claims }
         .flat_map{ |dc| dc.interaction_claims }
         .uniq
       @interaction_claims = results.reject do |ic|
-        ic.gene_claim.genes.first.nil? || exclude_chars.any? { |char| ic.drug_claim.drugs.first.name.include?(char) }
+        ic.gene_claim.genes.first.nil?
       end
 
-      # TODO: Same hack as above.
     end
   end
 

--- a/app/presenters/interaction_result_row_classes.rb
+++ b/app/presenters/interaction_result_row_classes.rb
@@ -23,7 +23,7 @@ module InteractionResultRowClasses
         'None'
       else
         @ids
-        .map { |d| @context.link_to(d.name, @context.drug_path(d.name))}
+        .map { |d| @context.link_to(d.name, @context.drug_path(CGI::escape(d.name)))}
         .join(', ').html_safe
       end
     end

--- a/app/presenters/related_drug_presenter.rb
+++ b/app/presenters/related_drug_presenter.rb
@@ -5,6 +5,6 @@ class RelatedDrugPresenter
   end
 
   def name_link(context)
-    context.link_to @drug.name, context.drug_path(@drug.name)
+    context.link_to @drug.name, context.drug_path(CGI::escape(@drug.name))
   end
 end

--- a/app/searches/lookup_drugs.rb
+++ b/app/searches/lookup_drugs.rb
@@ -1,7 +1,6 @@
 class LookupDrugs
 
   def self.find(search_terms, scope, wrapper_class)
-    search_terms = search_terms.reject { |term| term.include?('/') }
     raise 'You must specify at least one search term!' unless search_terms.any?
     results = match_search_terms_to_objects(search_terms, scope)
     results_to_drugs = match_objects_to_drugs(results, search_terms)

--- a/app/views/interaction_claims/_interaction_table_row.html.haml
+++ b/app/views/interaction_claims/_interaction_table_row.html.haml
@@ -11,7 +11,7 @@
           %small
             =interaction_table_row.gene_long_name.html_safe
     %td{title: interaction_table_row.drug_name}
-      =link_to truncate(interaction_table_row.drug_name.html_safe, length:50), drug_path(interaction_table_row.drug_name)
+      =link_to truncate(interaction_table_row.drug_name.html_safe, length:50), drug_path(CGI::escape(interaction_table_row.drug_name))
     %td
       =link_to interaction_table_row.types_string, interaction_claims_path(interaction_table_row.interaction_claim)
     %td
@@ -24,7 +24,7 @@
       = interaction_table_row.source_db_version
   - else
     %td{title: interaction_table_row.drug_name, class: "truncate"}
-      = link_to drug_path(interaction_table_row.drug_name) do
+      = link_to drug_path(CGI::escape(interaction_table_row.drug_name)) do
         %strong
           = interaction_table_row.drug_name.html_safe
     %td{title: interaction_table_row.gene_name + ' - ' + interaction_table_row.gene_long_name, class: "truncate"}

--- a/app/views/interaction_claims/_no_interaction_result.html.haml
+++ b/app/views/interaction_claims/_no_interaction_result.html.haml
@@ -16,5 +16,5 @@
           -if result.type == 'genes'
             %dt=link_to id.name, gene_path(id.name)
           -else
-            %dt=link_to id.name, drug_path(id.name)
+            %dt=link_to id.name, drug_path(CGI::escape(id.name))
           %dd="For search term: #{result.search_term}"

--- a/app/views/interaction_claims/_results_by_drug_table_row.html.haml
+++ b/app/views/interaction_claims/_results_by_drug_table_row.html.haml
@@ -2,7 +2,7 @@
   %td
     =results_by_drug_table_row.search_term
   %td{title: results_by_drug_table_row.drug_name, class: "truncate"}
-    = link_to drug_path(results_by_drug_table_row.drug_name) do
+    = link_to drug_path(CGI::escape(results_by_drug_table_row.drug_name)) do
       %strong
         = results_by_drug_table_row.drug_name
   %td

--- a/app/views/interaction_claims/_results_by_source_table_row.html.haml
+++ b/app/views/interaction_claims/_results_by_source_table_row.html.haml
@@ -1,7 +1,7 @@
 %tr
   %td
     - name_links = results_by_source_table_row.names.map do |(type, name)|
-      - link_to(name, "/#{type}s/#{name}")
+      - link_to(name, "/#{type}s/#{CGI::escape(name)}")
     = name_links.join(' and ').html_safe
   -results_by_source_table_row.sources.each do |in_source|
     %td

--- a/app/views/search/_drug_search_result.html.haml
+++ b/app/views/search/_drug_search_result.html.haml
@@ -1,5 +1,5 @@
 .well
   %em Drug
   %p
-    %strong=link_to r.name , drug_path(r.name)
+    %strong=link_to r.name , drug_path(CGI::escape(r.name))
     %p="Drug Claims:  #{r.drug_claims.count}"


### PR DESCRIPTION
@acoffman if you could review this PR, I'd appreciate it. It's not very DRY, but I wasn't sure how to achieve what I wanted without adding `CGI::escape` at every call to `drug_path`. Also, I couldn't find a defined method for `drug_path`... is this one of those nifty Rails conventions I simply don't know about?