### PR TITLE
Delete interactions before running the grouper

### DIFF
--- a/lib/genome/groupers/interaction_grouper.rb
+++ b/lib/genome/groupers/interaction_grouper.rb
@@ -3,9 +3,19 @@ module Genome
     class InteractionGrouper
       def self.run
         ActiveRecord::Base.transaction do
+          puts 'reset members'
+          reset_members
           puts 'add members'
           add_members
         end
+      end
+
+      def self.reset_members
+        DataModel::InteractionClaim.all.each do |interaction_claim|
+          interaction_claim.interaction = nil
+          interaction_claim.save
+        end
+        DataModel::Interaction.destroy_all
       end
 
       def self.add_members


### PR DESCRIPTION
@acoffman made the point that we should always delete the existing group instances before running a grouper. This was overlooked in the new interaction grouper created in PR #126. This PR adds a `reset_members` subroutine do delete existing interactions before running the interaction grouper.